### PR TITLE
前端：Phase 1 实现三栏主壳与对象切换

### DIFF
--- a/frontend/app/_components/authoring-workspace.tsx
+++ b/frontend/app/_components/authoring-workspace.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type { NavResponse } from "@/lib/contracts";
+
+import { MainPane } from "./main-pane";
+import { PreviewPane } from "./preview-pane";
+import { Sidebar } from "./sidebar";
+import {
+  getInitialSelection,
+  resolveSelection,
+  type AutosaveState,
+  type SelectedWorkspaceObject,
+  type WorkspaceSelection,
+} from "./workspace-model";
+
+export function AuthoringWorkspace({ initialNav }: { initialNav: NavResponse }) {
+  const [selection, setSelection] = useState<WorkspaceSelection>(() =>
+    getInitialSelection(initialNav),
+  );
+  const [autosaveState] = useState<AutosaveState>("saved");
+
+  const selectedObject = useMemo<SelectedWorkspaceObject>(
+    () => resolveSelection(initialNav, selection),
+    [initialNav, selection],
+  );
+
+  return (
+    <main className="h-full overflow-x-auto bg-zinc-100 text-zinc-950">
+      <div className="grid h-full min-w-[1060px] grid-cols-[280px_minmax(360px,1fr)_minmax(420px,46vw)]">
+        <Sidebar
+          nav={initialNav}
+          selection={selection}
+          onSelect={setSelection}
+        />
+        <MainPane
+          autosaveState={autosaveState}
+          selectedObject={selectedObject}
+        />
+        <PreviewPane selectedObject={selectedObject} />
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/_components/main-pane.tsx
+++ b/frontend/app/_components/main-pane.tsx
@@ -1,0 +1,213 @@
+import type { Problem, Topic } from "@/lib/contracts";
+
+import { AutosaveBadge } from "./ui/autosave-badge";
+import { HeaderBlock } from "./ui/header-block";
+import { InfoGroup } from "./ui/info-group";
+import { ModePill } from "./ui/mode-pill";
+import { PlaceholderContent } from "./ui/placeholder-content";
+import {
+  publishStatusLabel,
+  type AutosaveState,
+  type SelectedWorkspaceObject,
+} from "./workspace-model";
+
+export function MainPane({
+  autosaveState,
+  selectedObject,
+}: {
+  autosaveState: AutosaveState;
+  selectedObject: SelectedWorkspaceObject;
+}) {
+  const showAutosave = hasAutosaveSemantics(selectedObject);
+
+  return (
+    <section className="flex h-full flex-col border-r border-zinc-200 bg-zinc-50">
+      <div className="border-b border-zinc-200 bg-white px-6 py-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-xs font-medium text-zinc-500">中间编辑区</p>
+            <h2 className="mt-1 text-xl font-semibold">
+              {mainTitle(selectedObject)}
+            </h2>
+          </div>
+          {showAutosave ? <AutosaveBadge state={autosaveState} /> : null}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        <MainContent selectedObject={selectedObject} />
+      </div>
+    </section>
+  );
+}
+
+function MainContent({
+  selectedObject,
+}: {
+  selectedObject: SelectedWorkspaceObject;
+}) {
+  if (selectedObject.kind === "new_problem") {
+    return (
+      <PlaceholderContent
+        description="后续会在这里接入图片上传、OCR 进度和生成任务。"
+        title="新建题目"
+      />
+    );
+  }
+
+  if (selectedObject.kind === "search") {
+    return (
+      <PlaceholderContent
+        description="后续会在这里接入题目标题、标签和状态筛选。"
+        title="搜索题目"
+      />
+    );
+  }
+
+  if (selectedObject.kind === "problem") {
+    return <ProblemEditorPlaceholder problem={selectedObject.item} />;
+  }
+
+  if (selectedObject.kind === "site_home") {
+    const siteHome = selectedObject.item;
+
+    return (
+      <div className="space-y-6">
+        <HeaderBlock
+          description={siteHome.description}
+          status={siteHome.status}
+          title={siteHome.siteName}
+        />
+        <InfoGroup
+          items={[
+            ["精选专题", siteHome.featuredTopicIds.join("、") || "暂无"],
+            ["最近发布题目数量", `${siteHome.recentProblemLimit}`],
+            ["知识点入口", siteHome.knowledgeTags.join("、")],
+          ]}
+        />
+        <PlaceholderContent
+          description="Phase 1 只展示首页配置摘要，Phase 4 再接入可编辑的首页管理。"
+          title="首页管理占位"
+        />
+      </div>
+    );
+  }
+
+  return <TopicEditorPlaceholder topic={selectedObject.item} />;
+}
+
+function ProblemEditorPlaceholder({ problem }: { problem: Problem }) {
+  return (
+    <div className="space-y-6">
+      <HeaderBlock
+        description={problem.tags.join("、")}
+        status={problem.status}
+        title={problem.title}
+      />
+      <div className="grid grid-cols-2 gap-3">
+        <ModePill active label="编辑模式" />
+        <ModePill label="对话模式" />
+      </div>
+      <PlaceholderContent
+        description="后续会在这里显示作者对话、注释组消息和底部输入框。"
+        title="题目编辑占位"
+      />
+      <PlaceholderContent
+        description="Phase 1 不发送消息，只预留对话区域。"
+        title="后续对话区域占位"
+      />
+    </div>
+  );
+}
+
+function TopicEditorPlaceholder({ topic }: { topic: Topic }) {
+  return (
+    <div className="space-y-6">
+      <HeaderBlock
+        description={topic.description}
+        status={topic.status}
+        title={topic.title}
+      />
+      <InfoGroup
+        items={[
+          ["已收录题目", `${topic.items.length} 个`],
+          ["自动归类建议", `${topic.suggestedProblems.length} 条`],
+        ]}
+      />
+      <section>
+        <h3 className="text-sm font-semibold">已收录题目</h3>
+        <div className="mt-3 space-y-2">
+          {topic.items.length ? (
+            topic.items.map((item) => (
+              <div
+                className="rounded-md border border-zinc-200 bg-white px-4 py-3"
+                key={item.id}
+              >
+                <p className="text-sm font-medium">{item.title}</p>
+                <p className="mt-1 text-xs text-zinc-500">
+                  {item.tags.join("、")} · {publishStatusLabel(item.status)}
+                </p>
+              </div>
+            ))
+          ) : (
+            <p className="rounded-md border border-dashed border-zinc-300 px-4 py-6 text-sm text-zinc-500">
+              暂无已收录题目。
+            </p>
+          )}
+        </div>
+      </section>
+      <section>
+        <h3 className="text-sm font-semibold">自动归类建议</h3>
+        <div className="mt-3 space-y-2">
+          {topic.suggestedProblems.length ? (
+            topic.suggestedProblems.map((item) => (
+              <div
+                className="rounded-md border border-zinc-200 bg-white px-4 py-3"
+                key={item.id}
+              >
+                <p className="text-sm font-medium">{item.title}</p>
+                <p className="mt-1 text-xs leading-5 text-zinc-500">
+                  {item.reason}
+                </p>
+              </div>
+            ))
+          ) : (
+            <p className="rounded-md border border-dashed border-zinc-300 px-4 py-6 text-sm text-zinc-500">
+              暂无建议题目。
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function hasAutosaveSemantics(
+  selectedObject: SelectedWorkspaceObject,
+): boolean {
+  return (
+    selectedObject.kind === "problem" ||
+    selectedObject.kind === "site_home" ||
+    selectedObject.kind === "topic"
+  );
+}
+
+function mainTitle(selectedObject: SelectedWorkspaceObject): string {
+  if (selectedObject.kind === "new_problem") {
+    return "新建题目";
+  }
+
+  if (selectedObject.kind === "search") {
+    return "搜索题目";
+  }
+
+  if (selectedObject.kind === "problem") {
+    return selectedObject.item.shortTitle;
+  }
+
+  if (selectedObject.kind === "site_home") {
+    return "网站首页";
+  }
+
+  return selectedObject.item.title;
+}

--- a/frontend/app/_components/preview-pane.tsx
+++ b/frontend/app/_components/preview-pane.tsx
@@ -1,0 +1,86 @@
+import type { PublishStatus } from "@/lib/contracts";
+
+import {
+  previewUrlWithVersion,
+  publishStatusLabel,
+  type SelectedWorkspaceObject,
+} from "./workspace-model";
+
+export function PreviewPane({
+  selectedObject,
+}: {
+  selectedObject: SelectedWorkspaceObject;
+}) {
+  const preview = getPreview(selectedObject);
+
+  return (
+    <section className="flex h-full flex-col bg-white">
+      <div className="border-b border-zinc-200 px-5 py-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-zinc-500">右侧预览</p>
+            <h2 className="mt-1 truncate text-lg font-semibold">
+              {preview?.title ?? "暂无预览"}
+            </h2>
+          </div>
+        </div>
+        {preview?.status ? (
+          <p className="mt-2 text-xs text-zinc-500">
+            {publishStatusLabel(preview.status)}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="flex-1 bg-zinc-200 p-3">
+        {preview ? (
+          <iframe
+            className="h-full w-full rounded border border-zinc-300 bg-white"
+            key={preview.src}
+            src={preview.src}
+            title={`${preview.title}预览`}
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center rounded border border-dashed border-zinc-300 bg-zinc-50 text-sm text-zinc-500">
+            当前对象暂无网页预览。
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function getPreview(selectedObject: SelectedWorkspaceObject):
+  | { src: string; status: PublishStatus; title: string }
+  | null {
+  if (selectedObject.kind === "problem") {
+    return {
+      src: previewUrlWithVersion(
+        selectedObject.item.previewUrl,
+        selectedObject.item.previewVersion,
+      ),
+      status: selectedObject.item.status,
+      title: selectedObject.item.shortTitle,
+    };
+  }
+
+  if (selectedObject.kind === "site_home") {
+    return {
+      src: selectedObject.item.previewUrl,
+      status: selectedObject.item.status,
+      title: selectedObject.item.siteName,
+    };
+  }
+
+  if (selectedObject.kind === "topic") {
+    return {
+      src: previewUrlWithVersion(
+        selectedObject.item.previewUrl,
+        selectedObject.item.previewVersion,
+      ),
+      status: selectedObject.item.status,
+      title: selectedObject.item.title,
+    };
+  }
+
+  return null;
+}

--- a/frontend/app/_components/sidebar.tsx
+++ b/frontend/app/_components/sidebar.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from "react";
+
+import type { NavResponse } from "@/lib/contracts";
+
+import {
+  publishStatusLabel,
+  type WorkspaceSelection,
+} from "./workspace-model";
+
+export function Sidebar({
+  nav,
+  selection,
+  onSelect,
+}: {
+  nav: NavResponse;
+  selection: WorkspaceSelection;
+  onSelect: (selection: WorkspaceSelection) => void;
+}) {
+  return (
+    <aside className="flex h-full flex-col border-r border-zinc-200 bg-white">
+      <div className="border-b border-zinc-200 px-5 py-5">
+        <p className="text-xs font-medium text-teal-700">Phase 1</p>
+        <h1 className="mt-1 text-lg font-semibold tracking-tight">
+          创作后台
+        </h1>
+      </div>
+
+      <nav className="flex-1 space-y-6 overflow-y-auto px-3 py-4">
+        <SidebarSection title="入口">
+          <SidebarButton
+            active={selection.kind === "new_problem"}
+            detail="上传或录入题目"
+            label="新题目"
+            onClick={() => onSelect({ kind: "new_problem" })}
+          />
+          <SidebarButton
+            active={selection.kind === "search"}
+            detail="按标题、标签查找"
+            label="搜索"
+            onClick={() => onSelect({ kind: "search" })}
+          />
+        </SidebarSection>
+
+        <SidebarSection title="题目">
+          {nav.problems.map((problem) => (
+            <SidebarButton
+              active={
+                selection.kind === "problem" && selection.id === problem.id
+              }
+              badge={publishStatusLabel(problem.status)}
+              detail={problem.tags.join(" · ")}
+              key={problem.id}
+              label={problem.shortTitle}
+              onClick={() => onSelect({ kind: "problem", id: problem.id })}
+            />
+          ))}
+        </SidebarSection>
+
+        <SidebarSection title="网站">
+          <SidebarButton
+            active={selection.kind === "site_home"}
+            badge={publishStatusLabel(nav.siteHome.status)}
+            detail={nav.siteHome.siteName}
+            label="网站首页"
+            onClick={() => onSelect({ kind: "site_home" })}
+          />
+        </SidebarSection>
+
+        <SidebarSection title="专题">
+          {nav.topics.map((topic) => (
+            <SidebarButton
+              active={selection.kind === "topic" && selection.id === topic.id}
+              badge={publishStatusLabel(topic.status)}
+              detail={`${topic.items.length} 个题目`}
+              key={topic.id}
+              label={topic.title}
+              onClick={() => onSelect({ kind: "topic", id: topic.id })}
+            />
+          ))}
+        </SidebarSection>
+      </nav>
+    </aside>
+  );
+}
+
+function SidebarSection({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}) {
+  return (
+    <section>
+      <h2 className="px-2 text-xs font-semibold text-zinc-500">{title}</h2>
+      <div className="mt-2 space-y-1">{children}</div>
+    </section>
+  );
+}
+
+function SidebarButton({
+  active,
+  badge,
+  detail,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  badge?: string;
+  detail: string;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      aria-current={active ? "page" : undefined}
+      className={`w-full rounded-md border px-3 py-2 text-left transition ${
+        active
+          ? "border-teal-300 bg-teal-50 text-teal-950"
+          : "border-transparent text-zinc-700 hover:border-zinc-200 hover:bg-zinc-50"
+      }`}
+      onClick={onClick}
+      type="button"
+    >
+      <span className="flex items-start justify-between gap-3">
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium">{label}</span>
+          <span className="mt-1 block truncate text-xs text-zinc-500">
+            {detail}
+          </span>
+        </span>
+        {badge ? (
+          <span className="shrink-0 rounded border border-zinc-200 bg-white px-1.5 py-0.5 text-[11px] text-zinc-600">
+            {badge}
+          </span>
+        ) : null}
+      </span>
+    </button>
+  );
+}

--- a/frontend/app/_components/ui/autosave-badge.tsx
+++ b/frontend/app/_components/ui/autosave-badge.tsx
@@ -1,0 +1,20 @@
+import {
+  autosaveStateLabel,
+  type AutosaveState,
+} from "../workspace-model";
+
+export function AutosaveBadge({ state }: { state: AutosaveState }) {
+  const styles: Record<AutosaveState, string> = {
+    saving: "border-amber-200 bg-amber-50 text-amber-700",
+    saved: "border-teal-200 bg-teal-50 text-teal-700",
+    error: "border-red-200 bg-red-50 text-red-700",
+  };
+
+  return (
+    <span
+      className={`shrink-0 rounded border px-2 py-1 text-xs font-medium ${styles[state]}`}
+    >
+      {autosaveStateLabel(state)}
+    </span>
+  );
+}

--- a/frontend/app/_components/ui/header-block.tsx
+++ b/frontend/app/_components/ui/header-block.tsx
@@ -1,0 +1,27 @@
+import type { PublishStatus } from "@/lib/contracts";
+
+import { publishStatusLabel } from "../workspace-model";
+
+export function HeaderBlock({
+  description,
+  status,
+  title,
+}: {
+  description: string;
+  status: PublishStatus;
+  title: string;
+}) {
+  return (
+    <header>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-2xl font-semibold tracking-tight">{title}</h3>
+          <p className="mt-2 text-sm leading-6 text-zinc-600">{description}</p>
+        </div>
+        <span className="shrink-0 rounded border border-zinc-200 bg-white px-2 py-1 text-xs text-zinc-600">
+          {publishStatusLabel(status)}
+        </span>
+      </div>
+    </header>
+  );
+}

--- a/frontend/app/_components/ui/info-group.tsx
+++ b/frontend/app/_components/ui/info-group.tsx
@@ -1,0 +1,15 @@
+export function InfoGroup({ items }: { items: Array<[string, string]> }) {
+  return (
+    <dl className="grid gap-3">
+      {items.map(([label, value]) => (
+        <div
+          className="rounded-md border border-zinc-200 bg-white px-4 py-3"
+          key={label}
+        >
+          <dt className="text-xs font-medium text-zinc-500">{label}</dt>
+          <dd className="mt-1 text-sm text-zinc-800">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/frontend/app/_components/ui/mode-pill.tsx
+++ b/frontend/app/_components/ui/mode-pill.tsx
@@ -1,0 +1,19 @@
+export function ModePill({
+  active = false,
+  label,
+}: {
+  active?: boolean;
+  label: string;
+}) {
+  return (
+    <div
+      className={`rounded-md border px-4 py-3 text-center text-sm font-medium ${
+        active
+          ? "border-teal-300 bg-teal-50 text-teal-900"
+          : "border-zinc-200 bg-white text-zinc-500"
+      }`}
+    >
+      {label}
+    </div>
+  );
+}

--- a/frontend/app/_components/ui/placeholder-content.tsx
+++ b/frontend/app/_components/ui/placeholder-content.tsx
@@ -1,0 +1,14 @@
+export function PlaceholderContent({
+  description,
+  title,
+}: {
+  description: string;
+  title: string;
+}) {
+  return (
+    <section className="rounded-md border border-dashed border-zinc-300 bg-white px-4 py-5">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-zinc-500">{description}</p>
+    </section>
+  );
+}

--- a/frontend/app/_components/workspace-model.test.ts
+++ b/frontend/app/_components/workspace-model.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { NavResponse } from "@/lib/contracts";
+import navFixture from "../../fixtures/nav.json";
+
+import {
+  autosaveStateLabel,
+  getInitialSelection,
+  previewUrlWithVersion,
+  publishStatusLabel,
+  resolveSelection,
+} from "./workspace-model";
+
+const nav = navFixture as NavResponse;
+
+describe("workspace model", () => {
+  it("selects the first problem by default", () => {
+    expect(getInitialSelection(nav)).toEqual({
+      kind: "problem",
+      id: "problem_hongqiao_25",
+    });
+  });
+
+  it("falls back to site home when there are no problems", () => {
+    expect(getInitialSelection({ ...nav, problems: [] })).toEqual({
+      kind: "site_home",
+    });
+  });
+
+  it("resolves problem, topic, and site home selections", () => {
+    expect(resolveSelection(nav, { kind: "problem", id: "problem_heping_24" }))
+      .toMatchObject({
+        kind: "problem",
+        item: { shortTitle: "和平三模 24题" },
+      });
+    expect(resolveSelection(nav, { kind: "topic", id: "topic_path_minimum" }))
+      .toMatchObject({
+        kind: "topic",
+        item: { title: "二次函数路径最值" },
+      });
+    expect(resolveSelection(nav, { kind: "site_home" })).toMatchObject({
+      kind: "site_home",
+      item: { siteName: "数学可视化题库" },
+    });
+  });
+
+  it("falls back explicitly for unknown selection kinds", () => {
+    expect(
+      resolveSelection(nav, { kind: "settings" } as never),
+    ).toStrictEqual({
+      kind: "new_problem",
+    });
+  });
+
+  it("maps publish statuses to Chinese labels", () => {
+    expect(publishStatusLabel("draft")).toBe("草稿");
+    expect(publishStatusLabel("published")).toBe("已发布");
+    expect(publishStatusLabel("published_dirty")).toBe("已发布 · 有改动");
+  });
+
+  it("maps autosave states to Chinese labels", () => {
+    expect(autosaveStateLabel("saving")).toBe("正在保存");
+    expect(autosaveStateLabel("saved")).toBe("刚刚已保存");
+    expect(autosaveStateLabel("error")).toBe("保存失败");
+  });
+
+  it("adds or updates previewVersion in iframe URLs", () => {
+    expect(previewUrlWithVersion("/preview.html", "mock-1")).toBe(
+      "/preview.html?v=mock-1",
+    );
+    expect(previewUrlWithVersion("/preview.html?mode=work", "mock-2")).toBe(
+      "/preview.html?mode=work&v=mock-2",
+    );
+    expect(previewUrlWithVersion("/preview.html?v=old#step", "mock-3")).toBe(
+      "/preview.html?v=mock-3#step",
+    );
+  });
+});

--- a/frontend/app/_components/workspace-model.ts
+++ b/frontend/app/_components/workspace-model.ts
@@ -1,0 +1,116 @@
+import type {
+  NavResponse,
+  Problem,
+  PublishStatus,
+  SiteHome,
+  Topic,
+} from "@/lib/contracts";
+
+export type WorkspaceSelection =
+  | { kind: "new_problem" }
+  | { kind: "search" }
+  | { kind: "problem"; id: string }
+  | { kind: "site_home" }
+  | { kind: "topic"; id: string };
+
+export type AutosaveState = "saving" | "saved" | "error";
+
+export type SelectedWorkspaceObject =
+  | { kind: "new_problem" }
+  | { kind: "search" }
+  | { kind: "problem"; item: Problem }
+  | { kind: "site_home"; item: SiteHome }
+  | { kind: "topic"; item: Topic };
+
+export function getInitialSelection(nav: NavResponse): WorkspaceSelection {
+  const [firstProblem] = nav.problems;
+  if (firstProblem) {
+    return { kind: "problem", id: firstProblem.id };
+  }
+
+  if (nav.siteHome) {
+    return { kind: "site_home" };
+  }
+
+  const [firstTopic] = nav.topics;
+  if (firstTopic) {
+    return { kind: "topic", id: firstTopic.id };
+  }
+
+  return { kind: "new_problem" };
+}
+
+export function resolveSelection(
+  nav: NavResponse,
+  selection: WorkspaceSelection,
+): SelectedWorkspaceObject {
+  if (selection.kind === "problem") {
+    const item = nav.problems.find((problem) => problem.id === selection.id);
+    if (item) {
+      return { kind: "problem", item };
+    }
+  }
+
+  if (selection.kind === "topic") {
+    const item = nav.topics.find((topic) => topic.id === selection.id);
+    if (item) {
+      return { kind: "topic", item };
+    }
+  }
+
+  if (selection.kind === "site_home") {
+    return { kind: "site_home", item: nav.siteHome };
+  }
+
+  if (selection.kind === "search") {
+    return { kind: "search" };
+  }
+
+  if (selection.kind === "new_problem") {
+    return { kind: "new_problem" };
+  }
+
+  return { kind: "new_problem" };
+}
+
+export function publishStatusLabel(status: PublishStatus): string {
+  const labels: Record<PublishStatus, string> = {
+    draft: "草稿",
+    published: "已发布",
+    published_dirty: "已发布 · 有改动",
+  };
+
+  return labels[status];
+}
+
+export function autosaveStateLabel(state: AutosaveState): string {
+  const labels: Record<AutosaveState, string> = {
+    saving: "正在保存",
+    saved: "刚刚已保存",
+    error: "保存失败",
+  };
+
+  return labels[state];
+}
+
+export function previewUrlWithVersion(
+  previewUrl: string,
+  previewVersion?: string,
+): string {
+  if (!previewVersion) {
+    return previewUrl;
+  }
+
+  const hashIndex = previewUrl.indexOf("#");
+  const withoutHash =
+    hashIndex >= 0 ? previewUrl.slice(0, hashIndex) : previewUrl;
+  const hash = hashIndex >= 0 ? previewUrl.slice(hashIndex) : "";
+  const queryIndex = withoutHash.indexOf("?");
+  const path =
+    queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+  const query = queryIndex >= 0 ? withoutHash.slice(queryIndex + 1) : "";
+  const params = new URLSearchParams(query);
+  params.set("v", previewVersion);
+
+  return `${path}?${params.toString()}${hash}`;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="zh-CN" className="h-full antialiased">
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="flex h-screen flex-col">{children}</body>
     </html>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,44 +1,9 @@
-import Link from "next/link";
+import { AuthoringWorkspace } from "./_components/authoring-workspace";
+import { NavResponseSchema } from "@/lib/contracts";
+import { loadFixture } from "@/lib/mock/load-fixture";
 
-export default function Home() {
-  const links = [
-    { href: "/api/nav", label: "Mock API：导航数据" },
-    {
-      href: "/preview-fixtures/problems/hongqiao-25.html",
-      label: "题目预览 fixture",
-    },
-    {
-      href: "/preview-fixtures/topics/tianjin-sanmo-25.html",
-      label: "专题预览 fixture",
-    },
-    { href: "/preview-fixtures/site/home.html", label: "首页预览 fixture" },
-  ];
+export default async function Home() {
+  const nav = NavResponseSchema.parse(await loadFixture("nav.json"));
 
-  return (
-    <main className="min-h-screen bg-slate-50 px-8 py-10 text-slate-950">
-      <section className="mx-auto max-w-3xl rounded-lg border border-slate-200 bg-white p-8 shadow-sm">
-        <p className="text-sm font-medium uppercase tracking-wide text-teal-700">
-          Phase 0
-        </p>
-        <h1 className="mt-3 text-3xl font-semibold tracking-tight">
-          创作后台前端
-        </h1>
-        <p className="mt-4 max-w-2xl text-base leading-7 text-slate-600">
-          Phase 0 已建立独立的前端子项目、接口契约、fixture 数据和最小
-          mock API，后续页面会沿真实接口路径继续演进。
-        </p>
-        <div className="mt-8 grid gap-3">
-          {links.map((link) => (
-            <Link
-              className="rounded-md border border-slate-200 px-4 py-3 text-sm font-medium text-slate-700 transition hover:border-teal-300 hover:bg-teal-50 hover:text-teal-900"
-              href={link.href}
-              key={link.href}
-            >
-              {link.label}
-            </Link>
-          ))}
-        </div>
-      </section>
-    </main>
-  );
+  return <AuthoringWorkspace initialNav={nav} />;
 }


### PR DESCRIPTION
建立 Sidebar / MainPane / PreviewPane 工作台，支持题目、专题、首页切换与状态展示，为后续上传和编辑对话预留占位。